### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-08-05
+
 - Use `sqlx::query!` instead of `sqlx::query` everywhere
 - Add CLI argument `--repo-path=<string>`
 - Mark comments as resolved

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git-local-review"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-local-review"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Peter Morgenstern <mail@petergundel.de>"]
 edition = "2024"
 homepage = "https://github.com/peterfication/git-local-review"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ description = "A Terminal User Interface (TUI) for reviewing Git changes with lo
 
 exclude = [
   ".github",
-  "CLAUDE.md",
+  "AGENT.md",
   "lefthook.yml",
   "dprint.json",
+  "assets/screenshot.png",
   "src/**/*.snap",
 ]
 


### PR DESCRIPTION
- Use `sqlx::query!` instead of `sqlx::query` everywhere
- Add CLI argument `--repo-path=<string>`
- Mark comments as resolved