### PR TITLE
comments: Invalidate metadata on resolve/toggle to refresh indicators

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,3 +24,8 @@
 - **`src/models`**: Entities.
 - **`src/services`**: Business logic for the application.
 - **`src/services/mod.rs`**: ServiceHandler for services to handle events.
+
+## Comments & Indicators
+
+- Comment state changes (create/resolve/toggle) emit `AppEvent::CommentsMetadataInvalidated { review_id }` from `src/services/comment_service.rs`.
+- Views that render comment indicators (e.g. review details, comments list) listen for this event and reload comment metadata for the matching review.

--- a/src/event.rs
+++ b/src/event.rs
@@ -176,6 +176,8 @@ pub enum AppEvent {
         params: CommentsLoadParams,
         state: CommentsLoadingState,
     },
+    /// Comment metadata (resolved state, counts, indicators) is stale and should be reloaded.
+    CommentsMetadataInvalidated { review_id: Arc<ReviewId> },
     /// Create a new comment.
     CommentCreate {
         review_id: Arc<ReviewId>,

--- a/src/services/comment_service.rs
+++ b/src/services/comment_service.rs
@@ -209,12 +209,10 @@ impl CommentService {
                 // Send success event
                 events.send(AppEvent::CommentCreated(Arc::from(comment.clone())));
 
-                // Trigger reload of comments for the same target
-                events.send(AppEvent::CommentsLoad(CommentsLoadParams {
+                // Notify views to refresh comment metadata
+                events.send(AppEvent::CommentsMetadataInvalidated {
                     review_id: Arc::from(review_id),
-                    file_path: Arc::new(Some(file_path.to_string())),
-                    line_number: Arc::from(*line_number),
-                }));
+                });
             }
             Err(error) => {
                 events.send(AppEvent::CommentCreateError(Arc::from(format!(
@@ -264,6 +262,9 @@ impl CommentService {
                 events.send(AppEvent::CommentMarkedResolved {
                     comment_id: comment_id.into(),
                 });
+                events.send(AppEvent::CommentsMetadataInvalidated {
+                    review_id: Arc::from(comment.review_id.clone()),
+                });
             }
             Err(error) => {
                 events.send(AppEvent::CommentMarkResolvedError {
@@ -305,6 +306,9 @@ impl CommentService {
                     file_path: file_path.into(),
                     line_number,
                 });
+                events.send(AppEvent::CommentsMetadataInvalidated {
+                    review_id: review_id.into(),
+                });
             }
             Err(error) => {
                 events.send(AppEvent::CommentsMarkAllResolvedError {
@@ -339,6 +343,9 @@ impl CommentService {
                 events.send(AppEvent::CommentToggledResolved {
                     comment_id: comment_id.into(),
                     resolved: new_resolved_state,
+                });
+                events.send(AppEvent::CommentsMetadataInvalidated {
+                    review_id: Arc::from(comment.review_id.clone()),
                 });
             }
             Err(error) => {
@@ -439,6 +446,9 @@ impl CommentService {
                     line_number,
                     resolved_count: final_resolved_count,
                     unresolved_count: final_unresolved_count,
+                });
+                events.send(AppEvent::CommentsMetadataInvalidated {
+                    review_id: review_id.into(),
                 });
             }
             Err(error) => {
@@ -853,24 +863,13 @@ mod tests {
             _ => panic!("Expected CommentCreated event"),
         }
 
-        // Should send CommentsLoad event to reload
+        // Should send CommentsMetadataInvalidated event
         let event = events.try_recv().unwrap();
         match &*event {
-            Event::App(AppEvent::CommentsLoad(CommentsLoadParams {
-                review_id,
-                file_path,
-                line_number,
-            })) => {
+            Event::App(AppEvent::CommentsMetadataInvalidated { review_id }) => {
                 assert_eq!(review_id.to_string(), review.id);
-                match file_path.as_ref() {
-                    Some(file_path_conent) => {
-                        assert_eq!(file_path_conent, "src/main.rs");
-                    }
-                    None => panic!("Expected file path to be Some"),
-                }
-                assert_eq!(*line_number.as_ref(), None);
             }
-            _ => panic!("Expected CommentsLoad event"),
+            _ => panic!("Expected CommentsMetadataInvalidated event"),
         }
     }
 
@@ -908,29 +907,13 @@ mod tests {
             _ => panic!("Expected CommentCreated event"),
         }
 
-        // Should send CommentsLoad event to reload
+        // Should send CommentsMetadataInvalidated event
         let event = events.try_recv().unwrap();
         match &*event {
-            Event::App(AppEvent::CommentsLoad(CommentsLoadParams {
-                review_id,
-                file_path,
-                line_number,
-            })) => {
+            Event::App(AppEvent::CommentsMetadataInvalidated { review_id }) => {
                 assert_eq!(review_id.to_string(), review.id);
-                match file_path.as_ref() {
-                    Some(file_path_content) => {
-                        assert_eq!(file_path_content, "src/main.rs");
-                    }
-                    None => panic!("Expected file path to be Some"),
-                }
-                match line_number.as_ref() {
-                    Some(line_number_value) => {
-                        assert_eq!(*line_number_value, 42);
-                    }
-                    None => panic!("Expected line number to be Some"),
-                }
             }
-            _ => panic!("Expected CommentsLoad event"),
+            _ => panic!("Expected CommentsMetadataInvalidated event"),
         }
     }
 

--- a/src/views/comments_view.rs
+++ b/src/views/comments_view.rs
@@ -352,45 +352,10 @@ impl ViewHandler for CommentsView {
             AppEvent::CommentsLoadingState { params, state } => {
                 self.handle_comments_loading_state(params, state);
             }
-            AppEvent::CommentCreated(_comment) => {
-                // Reload comments when a new comment is created
-                self.request_comments_reload(app);
-            }
-            AppEvent::CommentCreateError(_error) => {
-                // Could show error message in UI, for now just reload
-                self.request_comments_reload(app);
-            }
-            AppEvent::CommentMarkedResolved { .. } => {
-                // Reload comments when a comment is marked as resolved
-                self.request_comments_reload(app);
-            }
-            AppEvent::CommentsMarkedAllResolved { .. } => {
-                // Reload comments when all comments are marked as resolved
-                self.request_comments_reload(app);
-            }
-            AppEvent::CommentMarkResolvedError { .. } => {
-                // Could show error message in UI, for now just reload
-                self.request_comments_reload(app);
-            }
-            AppEvent::CommentsMarkAllResolvedError { .. } => {
-                // Could show error message in UI, for now just reload
-                self.request_comments_reload(app);
-            }
-            AppEvent::CommentToggledResolved { .. } => {
-                // Reload comments when a comment's resolved state is toggled
-                self.request_comments_reload(app);
-            }
-            AppEvent::CommentsToggledAllResolved { .. } => {
-                // Reload comments when all comments' resolved state is toggled
-                self.request_comments_reload(app);
-            }
-            AppEvent::CommentToggleResolvedError { .. } => {
-                // Could show error message in UI, for now just reload
-                self.request_comments_reload(app);
-            }
-            AppEvent::CommentsToggleAllResolvedError { .. } => {
-                // Could show error message in UI, for now just reload
-                self.request_comments_reload(app);
+            AppEvent::CommentsMetadataInvalidated { review_id } => {
+                if self.target.review_id() == review_id.as_ref() {
+                    self.request_comments_reload(app);
+                }
             }
             _ => {
                 // Other events are not handled by this view

--- a/src/views/review_details_view.rs
+++ b/src/views/review_details_view.rs
@@ -212,9 +212,14 @@ impl ViewHandler for ReviewDetailsView {
             AppEvent::CommentsLoadingState { params, state } => {
                 self.handle_comments_loading_state(params, state);
             }
-            AppEvent::CommentCreated(_) => {
-                // Reload comment metadata when a comment is created
-                self.reload_comments(app);
+            AppEvent::CommentsMetadataInvalidated { review_id } => {
+                if self
+                    .review
+                    .as_ref()
+                    .is_some_and(|review| review.id.as_str() == review_id.as_ref())
+                {
+                    self.reload_comments(app);
+                }
             }
             _ => {
                 // Other events are not handled by this view
@@ -2221,16 +2226,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_comment_created_event_triggers_reload() {
+    async fn test_handle_comments_metadata_invalidated_triggers_reload() {
         let review = Review::builder().base_branch("main").build();
         let mut view = ReviewDetailsView::new(review.clone());
         let mut app = create_test_app().await;
 
-        // Create a dummy comment
-        let comment = Comment::test_comment(&review.id, "src/main.rs", None, "New comment");
-
-        // Handle CommentCreated event
-        view.handle_app_events(&mut app, &AppEvent::CommentCreated(Arc::new(comment)));
+        // Handle CommentsMetadataInvalidated event
+        view.handle_app_events(
+            &mut app,
+            &AppEvent::CommentsMetadataInvalidated {
+                review_id: Arc::from(review.id.as_str()),
+            },
+        );
 
         // Should trigger reload of comments
         assert!(app.events.has_pending_events());


### PR DESCRIPTION
When comment resolution state changes, the review details indicator could remain stale. Emit a metadata invalidation event from the comment service and have views reload for the matching review, keeping indicators up to date.